### PR TITLE
Add connection pool options to the config

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,13 +1,41 @@
 {
   // Configuration options available for the dbdt server:
 
+  database: {
+    // The connection URL for diesel
+    // If database_url is absent, it'll be pulled from the environment ($DATABASE_URL)
+    // This is for ease of development since a bunch of diesel's tooling expects to
+    // find it there. In production, it should live in config.json.
 
-  // The connection URL for diesel
-  // If database_url is absent, it'll be pulled from the environment ($DATABASE_URL)
-  // This is for ease of development since a bunch of diesel's tooling expects to
-  // find it there. In production, it should live in config.json.
+    // url: "postgres://dtdb:dtdbpassword@localhost:5437/dtdb_dev",
 
-  // database_url: "postgres://dtdb:dtdbpassword@localhost:5437/dtdb_dev",
+    connection_pool: {
+      // The maximum number of open connections in the pool (default: 10)
+      // max_size: 10,
+
+      // The minimum number of idle connections to keep in the pool
+      // If unset, this defaults to max_size. If greater than max_size, the maximum
+      // will still be respected.
+      // min_idle_count: 10,
+
+      // The maximum amount of time to keep a connection in the pool (default: 30 minutes)
+      // If the time for a connection expires while the connection is checked out, it
+      // will be closed when it's next returned to the pool.
+      // max_lifetime_ms: 1800000,
+
+      // The maximum amount of time to hold a connection open while it's been continuously
+      // idle (default: 10 minutes)
+      // idle_timeout_ms: 600000,
+
+      // The maximum amount of time to wait for a valid connection when trying to check
+      // one out (default: 30 seconds)
+      // connection_timeout_ms: 30000,
+
+      // When we select a connection to return when a client checks one out, should we
+      // make sure that connection still works? (default: true)
+      // test_connection_on_checkout: true,
+    }
+  },
 
   // The socket to listen on
   bind: {

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use diesel::pg::PgConnection;
 use diesel::r2d2::{Pool, ConnectionManager};
 
@@ -11,13 +13,24 @@ pub struct Application {
 
 impl Application {
     pub fn from_config(config: Config) -> anyhow::Result<Application> {
-        let connection_manager = ConnectionManager::<PgConnection>::new(config.database_url.clone());
+        let connection_manager = ConnectionManager::<PgConnection>::new(config.database.url.clone());
 
-        // TODO: make some of the connection pool options (e.g., max pool size, expiration, etc.)
-        //       configurable through `config`
-        let connection_pool =
+        let mut connection_pool_builder =
             Pool::builder()
-                .build(connection_manager)?;
+                .min_idle(config.database.connection_pool.min_idle_count)
+                .max_lifetime(config.database.connection_pool.max_lifetime_ms.map(Duration::from_millis))
+                .idle_timeout(config.database.connection_pool.idle_timeout_ms.map(Duration::from_millis))
+                .test_on_check_out(config.database.connection_pool.test_connection_on_checkout);
+        
+        if let Some(max_size) = config.database.connection_pool.max_size {
+            connection_pool_builder = connection_pool_builder.max_size(max_size);
+        }
+
+        if let Some(connection_timeout_ms) = config.database.connection_pool.connection_timeout_ms {
+            connection_pool_builder = connection_pool_builder.connection_timeout(Duration::from_millis(connection_timeout_ms));
+        }
+
+        let connection_pool = connection_pool_builder.build(connection_manager)?;
         
         Ok(Application {
             config,

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,10 +2,27 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize)]
 pub struct Config {
-    #[serde(default = "default_database_url")]
-    pub database_url: String,
+    pub database: Database,
     pub bind: Bind,
     pub log: log4rs::config::RawConfig,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Database {
+    #[serde(default = "default_database_url")]
+    pub url: String,
+    pub connection_pool: ConnectionPool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ConnectionPool {
+    pub max_size: Option<u32>,
+    pub min_idle_count: Option<u32>,
+    pub max_lifetime_ms: Option<u64>,
+    pub idle_timeout_ms: Option<u64>,
+    pub connection_timeout_ms: Option<u64>,
+    #[serde(default = "default_test_on_checkout")]
+    pub test_connection_on_checkout: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -22,4 +39,8 @@ pub enum Bind {
 
 fn default_database_url() -> String {
     std::env::var("DATABASE_URL").expect("No database URL found in config or environment")
+}
+
+fn default_test_on_checkout() -> bool {
+    true
 }


### PR DESCRIPTION
TSIA. The `config.json` changes probably read a bit better with whitespace changes turned off.

Closes #3 