### PR TITLE
Add url() and index_url() helpers to the view layer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ json5 = "0.4.1"
 log4rs = "1.2.0"
 log = "0.4.17"
 anyhow = "1.0"
+serde_json = "1.0.97"
 
 # Workspace Setup
 

--- a/src/handlers/seasons.rs
+++ b/src/handlers/seasons.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
+use axum::Router;
 use axum::extract::{State, Path};
+use axum::routing::get;
 use diesel::dsl::today;
 use diesel::prelude::*;
 use tera::Context;
@@ -11,7 +13,13 @@ use crate::application::Application;
 
 use super::HandlerResult;
 
-pub async fn list(
+pub fn routes() -> Router<Arc<Application>> {
+    Router::new()
+        .route("/", get(list))
+        .route("/:season_id", get(single))
+}
+
+async fn list(
     State(app): State<Arc<Application>>
 ) -> HandlerResult {
     let all_seasons = app.with_db_connection(|db| {
@@ -22,7 +30,7 @@ pub async fn list(
     Ok(app.views.render_page_with("seasons/list", &context)?)
 }
 
-pub async fn single(
+async fn single(
     Path(season_id): Path<String>,
     State(app): State<Arc<Application>>
 ) -> HandlerResult {

--- a/src/handlers/toaster.rs
+++ b/src/handlers/toaster.rs
@@ -1,12 +1,17 @@
 use std::sync::Arc;
 
-use axum::extract::State;
+use axum::{extract::State, Router, routing::get};
 
 use crate::application::Application;
 
 use super::HandlerResult;
 
-pub async fn toaster(
+pub fn routes() -> Router<Arc<Application>> {
+    Router::new()
+        .route("/", get(toaster))
+}
+
+async fn toaster(
     State(app): State<Arc<Application>>
 ) -> HandlerResult {
     Ok(app.views.render_page("toaster")?)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,4 @@ pub mod data;
 pub mod handlers;
 pub mod routes;
 pub mod view;
+pub mod util;

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,17 +1,18 @@
 use std::sync::Arc;
 
-use axum::{Router, routing::get};
+use axum::Router;
 use tower_http::trace::{self, TraceLayer};
 use tracing::Level;
 
-use crate::{handlers::{toaster::toaster, seasons}, application::Application};
+use crate::{handlers::{toaster, seasons}, application::Application, util, data::{models::season::Season, identifiers::IdentifierPrefix}};
 
 pub fn build_routes(app: Arc<Application>) -> Router {
-
     Router::new()
-        .route("/seasons", get(seasons::list))
-        .route("/seasons/:season_id", get(seasons::single))
-        .route("/toaster", get(toaster))
+        .nest(
+            util::route_for_id_prefix(Season::identifier_prefix()),
+            seasons::routes()
+        )
+        .nest("/toaster", toaster::routes())
         .with_state(app)
         .layer(
             TraceLayer::new_for_http()

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,15 @@
+pub fn route_for_id_prefix(id_prefix: &str) -> &'static str {
+    match id_prefix {
+        "acct" => "/accounts",
+        "award" => "/awards",
+        "claim" => "/claims",
+        "ecterm" => "/ec_terms",
+        "media" => "/media",
+        "person" => "/people",
+        "season" => "/seasons",
+        "show" => "/shows",
+        "tag" => "/tags",
+        "work" => "/worked_on",
+        _ => panic!("Unknown id prefix {id_prefix}s"),
+    }
+}

--- a/src/view/helpers/mod.rs
+++ b/src/view/helpers/mod.rs
@@ -1,0 +1,1 @@
+pub mod url;

--- a/src/view/helpers/url.rs
+++ b/src/view/helpers/url.rs
@@ -1,0 +1,96 @@
+use std::{collections::HashMap, fmt::Display, error::Error};
+
+use serde_json::Value;
+
+use crate::util;
+
+pub fn url(args: &HashMap<String, Value>) -> tera::Result<Value> {
+    let id_str = extract_id(args)?;
+    let id_prefix = extract_id_prefix(id_str)?;
+    let route = util::route_for_id_prefix(id_prefix);
+
+    match extract_action(args) {
+        "view" => Ok(Value::String(format!("{route}/{id_str}"))),
+        action => Ok(Value::String(format!("{route}/{id_str}/{action}"))),
+    }
+}
+
+pub fn index_url(args: &HashMap<String, Value>) -> tera::Result<Value> {
+    let id_str = extract_id(args)?;
+    let id_prefix = extract_id_prefix(id_str)?;
+    let route = util::route_for_id_prefix(id_prefix);
+
+    Ok(Value::String(route.to_string()))
+}
+
+fn extract_id<'a>(args: &'a HashMap<String, Value>) -> tera::Result<&'a str> {
+    if let Some(Value::String(id_str)) = args.get("id") {
+        Ok(id_str.as_str())
+    } else if let Some(Value::Object(props)) = args.get("for") {
+        if let Some(Value::String(id_str)) = props.get("id") {
+            Ok(id_str.as_str())
+        } else {
+            Err(
+                tera::Error::call_function(
+                    "url",
+                    UrlHelperError::InvalidArguments("value of 'for' in url(for=<model>) must be an object with an id property".to_string()),
+                )
+            )
+        }
+    } else {
+        Err(
+            tera::Error::call_function(
+                "url",
+                UrlHelperError::InvalidArguments("expected one of for=<model object> or id=<string>, got neither".to_string())
+            )
+        )
+    }
+}
+
+fn extract_id_prefix<'a>(id_str: &'a str) -> tera::Result<&'a str> {
+    match id_str.split("_").collect::<Vec<_>>().as_slice() {
+        &[prefix, _token] => Ok(prefix),
+        _ => Err(
+            tera::Error::call_function(
+                "url",
+                UrlHelperError::InvalidIdentifier(id_str.to_string()),
+            )
+        ),
+    }
+}
+
+// Look up the "action" arg, defaulting to `"view"` if it's not present
+// This allows e.g., url(for=show) and url(for=show,action="view") to behave
+// identically. Why do we want this? Well, when looping over a list of actions
+// tera doesn't make it easy to skip passing an argument for one of those
+// action names. On other other hand, we don't want to have to write out
+// `action="view"` normally, so we adopt the convention that:
+//
+//   (missing or malformed) means the same as "view", which produces
+//   a URL with no final component
+fn extract_action<'a>(args: &'a HashMap<String, Value>) -> &'a str {
+    if let Some(Value::String(action_str)) = args.get("action") {
+        action_str.as_str()
+    } else {
+        "view"
+    }
+}
+
+#[derive(Debug)]
+enum UrlHelperError {
+    InvalidArguments(String),
+    InvalidIdentifier(String)
+}
+
+impl Display for UrlHelperError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UrlHelperError::InvalidArguments(details) =>
+                write!(f, "invalid arguments to url() helper function: {details}"),
+            UrlHelperError::InvalidIdentifier(bad_id) =>
+                write!(f, "invalid identifier {bad_id}, should be of the form \"<prefix>_<id>\""),
+        }
+    }
+}
+
+impl Error for UrlHelperError {}

--- a/src/view/helpers/url.rs
+++ b/src/view/helpers/url.rs
@@ -4,6 +4,15 @@ use serde_json::Value;
 
 use crate::util;
 
+// Usage:
+//   url(for=<model object>)
+//     -> a URL for viewing that object
+//   url(for=<model object>, action=<string>)
+//     -> a URL for performing the indicated action on that object
+//   url(id=<string>)
+//     -> a URL for viewing the object identified by the given token (string)
+//   url(id=<string>, action=<string>)
+//     -> a URL for performing the indicated action on the object identified by the given token (string)
 pub fn url(args: &HashMap<String, Value>) -> tera::Result<Value> {
     let id_str = extract_id(args)?;
     let id_prefix = extract_id_prefix(id_str)?;
@@ -15,6 +24,12 @@ pub fn url(args: &HashMap<String, Value>) -> tera::Result<Value> {
     }
 }
 
+
+// Usage:
+//   index_url(for=<model object>)
+//     -> a URL for listing instances of the same type as that object
+//   index_url(id=<string>)
+//     -> a URL for listing instances of the type identified by the given token (string)
 pub fn index_url(args: &HashMap<String, Value>) -> tera::Result<Value> {
     let id_str = extract_id(args)?;
     let id_prefix = extract_id_prefix(id_str)?;

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -3,6 +3,8 @@ use tera::Context;
 use tera::Tera;
 use include_dir::{include_dir, Dir, DirEntry, File};
 
+mod helpers;
+
 static TEMPLATES_DIR: Dir<'static> = include_dir!("$CARGO_MANIFEST_DIR/views");
 
 pub struct Views {
@@ -22,6 +24,10 @@ impl Views {
         tera.check_macro_files()?;
 
         log::debug!("Successfully loaded templates: {:?}", tera.get_template_names().collect::<Vec<&str>>());
+
+        // Register helper functions
+        tera.register_function("url", helpers::url::url);
+        tera.register_function("index_url", helpers::url::index_url);
 
         Ok(Views {tera})
     }

--- a/views/pages/seasons/list.tera.html
+++ b/views/pages/seasons/list.tera.html
@@ -4,7 +4,7 @@
 <h2>Seasons</h2>
 <ul>
   {% for season in seasons %}
-    <li><a href="/seasons/{{ season.id }}">{{ season.title }}</a></li>
+    <li><a href="{{ url(for=season) }}">{{ season.title }}</a></li>
   {% endfor %}
 </ul>
 {% endblock content %}

--- a/views/pages/seasons/single.tera.html
+++ b/views/pages/seasons/single.tera.html
@@ -3,6 +3,6 @@
 {% block content %}
 <h2>{{ season.title }}</h2>
 <p>
-  <a href="/seasons">&larr; All seasons</a>
+  <a href="{{ index_url(for=season) }}">&larr; All seasons</a>
 </p>
 {% endblock content %}


### PR DESCRIPTION
Add a few view helper functions for generating URLs given model objects or ids. In the process, enable factoring routing logic into the individual handler modules (e.g., the `handlers::seasons` module builds its own router and the core application router simply mounts that one in at `/seasons`). Since the view helpers and application router now both want to be able to map identifier prefixes to route prexies consistently, they use the same function for doing so—it lives in `util`.

Closes #10 