### PR TITLE
Enable serde on chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde = {version = "1", features = ["derive"]}
 rand = "0.8.5"
 identifier_prefix = {path = "./identifier_prefix"}
 diesel = { version = "2.0.0", features = ["postgres", "chrono", "r2d2"] }
-chrono = "0.4.24"
+chrono = { version = "0.4.24", features = ["serde"] }
 dotenvy = "0.15"
 ordinal = "0.3.2"
 axum = "0.6.18"

--- a/src/data/models/season.rs
+++ b/src/data/models/season.rs
@@ -40,10 +40,12 @@ impl Serialize for Season {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: serde::Serializer {
-        let mut season = serializer.serialize_struct("Season", 3)?;
+        let mut season = serializer.serialize_struct("Season", 5)?;
         season.serialize_field("id", &self.id)?;
         season.serialize_field("season_number", &self.season_number)?;
         season.serialize_field("title", &self.title())?;
+        season.serialize_field("start_year", &self.start_year)?;
+        season.serialize_field("end_year", &self.end_year)?;
         season.end()
     }
 }


### PR DESCRIPTION
Turns out there's a `serde` feature on the `chrono` crate that enables serialization of dates/datetimes, so we don't need custom serializers. It outputs ISO 8601 dates and times, so we probably do eventually want tera helpers for formatting dates, but that can probably be its own crate.

Closes #5 