### PR TITLE
Add serializers for models

### DIFF
--- a/src/data/models/account.rs
+++ b/src/data/models/account.rs
@@ -4,11 +4,13 @@ use diesel::pg::Pg;
 use diesel::{prelude::*, FromSqlRow, AsExpression};
 use diesel::serialize::ToSql;
 use diesel::sql_types::{Nullable, Text};
+use serde::Serialize;
 
 use crate::data::{schema::accounts, identifiers::Identifier};
 use identifier_prefix::identifier_prefix;
 
-#[derive(Debug, FromSqlRow, AsExpression)]
+#[derive(Debug, FromSqlRow, AsExpression, Serialize)]
+#[serde(rename_all = "snake_case")]
 #[diesel(sql_type = Text)]
 pub enum Role {
     Default,
@@ -52,10 +54,11 @@ impl Account {
     }
 }
 
-#[derive(Identifiable, Insertable)]
+#[derive(Identifiable, Insertable, Serialize)]
 #[diesel(table_name = accounts)]
 struct CreateOrUpdateAccount {
     id: Identifier<Account>,
+    #[serde(skip_serializing)]
     oidc_subject: String,
     name: Option<String>,
     email: Option<String>,

--- a/src/data/models/award.rs
+++ b/src/data/models/award.rs
@@ -1,12 +1,13 @@
 use chrono::{DateTime, Utc};
 use diesel::prelude::*;
 use identifier_prefix::identifier_prefix;
+use serde::Serialize;
 
 use crate::data::{identifiers::Identifier, schema::awards};
 
 use super::{person::Person, show::Show, season::Season};
 
-#[derive(Debug, Identifiable, Queryable, Selectable, Associations)]
+#[derive(Debug, Identifiable, Queryable, Selectable, Associations, Serialize)]
 #[diesel(belongs_to(Person))]
 #[diesel(belongs_to(Season))]
 #[diesel(belongs_to(Show))]

--- a/src/data/models/ec_term.rs
+++ b/src/data/models/ec_term.rs
@@ -1,6 +1,7 @@
 use chrono::{NaiveDate, DateTime, Utc, Datelike};
 use diesel::prelude::*;
 use identifier_prefix::identifier_prefix;
+use serde::{Serialize, ser::SerializeStruct};
 
 use crate::data::{identifiers::Identifier, schema::ec_terms};
 
@@ -55,6 +56,23 @@ impl ECTerm {
         } else {
             format!("{}–{}", start_year, end_year)
         }
+    }
+}
+
+impl Serialize for ECTerm {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer {
+        let mut ec_term = serializer.serialize_struct("ECTerm", 8)?;
+        ec_term.serialize_field("id", &self.id)?;
+        ec_term.serialize_field("person_id", &self.person_id)?;
+        ec_term.serialize_field("role", &self.role)?;
+        ec_term.serialize_field("start_year", &self.start_year)?;
+        ec_term.serialize_field("end_year", &self.end_year)?;
+        ec_term.serialize_field("year_range", &self.format_year_range())?;
+        ec_term.serialize_field("created_at", &self.created_at)?;
+        ec_term.serialize_field("updated_at", &self.updated_at)?;
+        ec_term.end()
     }
 }
 

--- a/src/data/models/media.rs
+++ b/src/data/models/media.rs
@@ -1,10 +1,11 @@
 use chrono::{Utc, DateTime};
 use diesel::prelude::*;
+use serde::Serialize;
 
 use crate::data::{identifiers::Identifier, schema::media};
 use identifier_prefix::identifier_prefix;
 
-#[derive(Debug, Identifiable, Queryable, Selectable)]
+#[derive(Debug, Identifiable, Queryable, Selectable, Serialize)]
 #[diesel(table_name = media)]
 #[identifier_prefix(media)]
 pub struct Media {

--- a/src/data/models/person.rs
+++ b/src/data/models/person.rs
@@ -1,12 +1,13 @@
 use chrono::{DateTime, Utc};
 use diesel::prelude::*;
 use identifier_prefix::identifier_prefix;
+use serde::Serialize;
 
 use crate::data::{identifiers::Identifier, schema::people};
 
 use super::{media::Media, account::Account};
 
-#[derive(Debug, Identifiable, Queryable, Selectable, Associations)]
+#[derive(Debug, Identifiable, Queryable, Selectable, Associations, Serialize)]
 #[diesel(belongs_to(Account))]
 #[diesel(table_name = people)]
 #[identifier_prefix(person)]

--- a/src/data/models/profile_claimed.rs
+++ b/src/data/models/profile_claimed.rs
@@ -1,12 +1,13 @@
 use chrono::{DateTime, Utc};
 use diesel::prelude::*;
 use identifier_prefix::identifier_prefix;
+use serde::Serialize;
 
 use crate::data::{identifiers::Identifier, schema::profile_claimed};
 
 use super::{account::Account, person::Person};
 
-#[derive(Debug, Identifiable, Queryable, Selectable, Associations)]
+#[derive(Debug, Identifiable, Queryable, Selectable, Associations, Serialize)]
 #[diesel(belongs_to(Account))]
 #[diesel(belongs_to(Person))]
 #[diesel(table_name = profile_claimed)]

--- a/src/data/models/show.rs
+++ b/src/data/models/show.rs
@@ -1,13 +1,13 @@
-use chrono::{NaiveDate, DateTime, Utc};
+use chrono::{NaiveDate, DateTime, Utc, Datelike};
 use diesel::prelude::*;
 use identifier_prefix::identifier_prefix;
-use serde::Serialize;
+use serde::{Serialize, ser::SerializeStruct};
 
 use crate::data::{identifiers::Identifier, schema::shows};
 
 use super::{season::Season, media::Media};
 
-#[derive(Debug, Identifiable, Queryable, Selectable, Associations, Serialize)]
+#[derive(Debug, Identifiable, Queryable, Selectable, Associations)]
 #[diesel(belongs_to(Season))]
 #[diesel(table_name = shows)]
 #[identifier_prefix(show)]
@@ -64,6 +64,76 @@ impl Show {
             poster_id: self.poster_id.clone(),
             banner_id: self.banner_id.clone(),
         }
+    }
+
+    pub fn render_show_dates(&self) -> String {
+        if self.use_legacy_date_rendering {
+            let year = self.opening_date.year();
+            let month = self.opening_date.month();
+
+            match month {
+                1..=3 => format!("Winter {year}"),
+                4..=6 => format!("Spring {year}"),
+                7..=9 => format!("Summer {year}"),
+                10..=12 => format!("Fall {year}"),
+                _ => format!("An unkowable time spread across the moments of {year}"),
+            }
+        } else {
+            let opening_year = self.opening_date.year();
+            let closing_year = self.closing_date.year();
+            if opening_year == closing_year {
+                let opening_month = self.opening_date.month();
+                let closing_month = self.closing_date.month();
+                if opening_month == closing_month {
+                    // e.g., November 03–18, 2023
+                    format!("{}–{}", self.opening_date.format("%B %d"), self.closing_date.format("%d, %Y"))
+                } else {
+                    // e.g., September 15—October 15, 2023
+                    format!("{}–{}", self.opening_date.format("%B %d"), self.closing_date.format("%B %d, %Y"))
+                }
+            } else {
+                // e.g., December 15, 2023—January 15, 2024
+                format!("{}–{}", self.opening_date.format("%B %d, %Y"), self.closing_date.format("%B %d, %Y"))
+            }
+        }
+    }
+}
+
+// pub struct Show {
+//     pub id: Identifier<Show>,
+//     pub title: String,
+//     pub season_id: Identifier<Season>,
+//     pub author: String,
+//     pub description: Option<String>,
+//     pub fun_facts: Option<String>,
+//     pub opening_date: NaiveDate,
+//     pub closing_date: NaiveDate,
+//     pub use_legacy_date_rendering: bool,
+//     pub poster_id: Option<Identifier<Media>>,
+//     pub banner_id: Option<Identifier<Media>>,
+//     pub created_at: DateTime<Utc>,
+//     pub updated_at: DateTime<Utc>,
+// }
+
+impl Serialize for Show {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer {
+        let mut show = serializer.serialize_struct("Show", 13)?;
+        show.serialize_field("id", &self.id)?;
+        show.serialize_field("title", &self.title)?;
+        show.serialize_field("season_id", &self.season_id)?;
+        show.serialize_field("author", &self.author)?;
+        show.serialize_field("description", &self.description)?;
+        show.serialize_field("fun_facts", &self.fun_facts)?;
+        show.serialize_field("opening_date", &self.opening_date)?;
+        show.serialize_field("closing_date", &self.closing_date)?;
+        show.serialize_field("formatted_show_dates", &self.render_show_dates())?;
+        show.serialize_field("poster_id", &self.poster_id)?;
+        show.serialize_field("banner_id", &self.banner_id)?;
+        show.serialize_field("created_at", &self.created_at)?;
+        show.serialize_field("updated_at", &self.updated_at)?;
+        show.end()
     }
 }
 

--- a/src/data/models/show.rs
+++ b/src/data/models/show.rs
@@ -1,12 +1,13 @@
 use chrono::{NaiveDate, DateTime, Utc};
 use diesel::prelude::*;
 use identifier_prefix::identifier_prefix;
+use serde::Serialize;
 
 use crate::data::{identifiers::Identifier, schema::shows};
 
 use super::{season::Season, media::Media};
 
-#[derive(Debug, Identifiable, Queryable, Selectable, Associations)]
+#[derive(Debug, Identifiable, Queryable, Selectable, Associations, Serialize)]
 #[diesel(belongs_to(Season))]
 #[diesel(table_name = shows)]
 #[identifier_prefix(show)]

--- a/src/data/models/show.rs
+++ b/src/data/models/show.rs
@@ -76,7 +76,7 @@ impl Show {
                 4..=6 => format!("Spring {year}"),
                 7..=9 => format!("Summer {year}"),
                 10..=12 => format!("Fall {year}"),
-                _ => format!("An unkowable time spread across the moments of {year}"),
+                _ => format!("An unknowable time spread across the moments of {year}"),
             }
         } else {
             let opening_year = self.opening_date.year();
@@ -98,22 +98,6 @@ impl Show {
         }
     }
 }
-
-// pub struct Show {
-//     pub id: Identifier<Show>,
-//     pub title: String,
-//     pub season_id: Identifier<Season>,
-//     pub author: String,
-//     pub description: Option<String>,
-//     pub fun_facts: Option<String>,
-//     pub opening_date: NaiveDate,
-//     pub closing_date: NaiveDate,
-//     pub use_legacy_date_rendering: bool,
-//     pub poster_id: Option<Identifier<Media>>,
-//     pub banner_id: Option<Identifier<Media>>,
-//     pub created_at: DateTime<Utc>,
-//     pub updated_at: DateTime<Utc>,
-// }
 
 impl Serialize for Show {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/data/models/worked_on.rs
+++ b/src/data/models/worked_on.rs
@@ -1,12 +1,14 @@
 use chrono::{DateTime, Utc};
 use diesel::{prelude::*, pg::Pg, sql_types::Text, deserialize::{FromSql, FromSqlRow}, serialize::ToSql, expression::AsExpression};
 use identifier_prefix::identifier_prefix;
+use serde::Serialize;
 
 use crate::data::{identifiers::Identifier, schema::worked_on};
 
 use super::{person::Person, show::Show};
 
-#[derive(Debug, Clone, FromSqlRow, AsExpression)]
+#[derive(Debug, Clone, FromSqlRow, AsExpression, Serialize)]
+#[serde(rename_all = "snake_case")]
 #[diesel(sql_type = Text)]
 pub enum Context {
     Cast,
@@ -14,7 +16,7 @@ pub enum Context {
     SpecialThanks,
 }
 
-#[derive(Debug, Identifiable, Queryable, Selectable, Associations)]
+#[derive(Debug, Identifiable, Queryable, Selectable, Associations, Serialize)]
 #[diesel(belongs_to(Person))]
 #[diesel(belongs_to(Show))]
 #[diesel(table_name = worked_on)]


### PR DESCRIPTION
TSIA.

Custom serializers for `ECTerm` and `Show` because we have some derived fields to pass into the view layer, but everything else now just `derive(Serialize)`es.

Closes #6 